### PR TITLE
Fix build with Python 3.7

### DIFF
--- a/bpl_subset/libs/python/src/converter/builtin_converters.cpp
+++ b/bpl_subset/libs/python/src/converter/builtin_converters.cpp
@@ -45,10 +45,15 @@ namespace
   {
       return PyString_Check(obj) ? PyString_AsString(obj) : 0;
   }
-#else
+#elif PY_VERSION_HEX < 0x03070000
   void* convert_to_cstring(PyObject* obj)
   {
       return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
+  }
+#else
+  void* convert_to_cstring(PyObject* obj)
+  {
+      return PyUnicode_Check(obj) ? const_cast<void*>(reinterpret_cast<const void*>(_PyUnicode_AsString(obj))) : 0;
   }
 #endif
 


### PR DESCRIPTION
This is just the [same commit as in boost](https://github.com/boostorg/python/commit/660487c43fde76f3e64f1cb2e644500da92fe582), which is needed for Python 3.7 compatibility

Probably a better idea to just update this repo to the newest version of boost, i just made this fork so i can get it to work right now.